### PR TITLE
Add required field indicator to the region label in the SalesByRegion…

### DIFF
--- a/apre-client/src/app/reports/sales/sales-by-region/sales-by-region.component.ts
+++ b/apre-client/src/app/reports/sales/sales-by-region/sales-by-region.component.ts
@@ -13,7 +13,7 @@ import { ChartComponent } from '../../../shared/chart/chart.component';
     <div class="region-container">
       <form class="form" [formGroup]="regionForm" (ngSubmit)="onSubmit()">
         <div class="form__group">
-          <label class="label" for="region">Region</label>
+          <label class="label" for="region">Region<span class="required">*</span></label> <!-- Added a span tag with an * for the required label -->
           <select class="select" formControlName="region" id="region" name="region">
             @for(region of regions; track region) {
               <option value="{{ region }}">{{ region }}</option>


### PR DESCRIPTION
…Component

Added a required field indicator to the region label in the SalesByRegionComponent. I added a span tag with a class name of 'required' and an asterisk within the label tag for the region label on line 16 of sales-by-region.component.ts. I didn't have to write the CSS to make the asterisk red as I originally anticipated. There was already a required class in the global styles.css that does this. I didn't realize this when I started. I used the span tag because it's an inline tag, which means the asterisk would line up with the Region label and not go onto the next line. I found that the span tag must be within the label tag, otherwise the asterisk goes below the Region label. I did this before discovering that it was done the exact same way in the UserCreateComponent.

This was done for task m-023.