### PR TITLE
Add monthly sales data API and SalesByMonthComponent for task M-062

### DIFF
--- a/apre-client/src/app/app.routes.ts
+++ b/apre-client/src/app/app.routes.ts
@@ -25,6 +25,7 @@ import { CallDurationByDateRangeComponent } from './reports/agent-performance/ca
 import { ChannelRatingByMonthComponent } from './reports/customer-feedback/channel-rating-by-month/channel-rating-by-month.component';
 import { CustomerFeedbackComponent } from './reports/customer-feedback/customer-feedback.component';
 import { SalesByRegionTabularComponent } from './reports/sales/sales-by-region-tabular/sales-by-region-tabular.component';
+import { SalesByMonthComponent } from './reports/sales/sales-by-month/sales-by-month.component';
 
 // Export user-management routes
 export const userManagementRoutes: Routes = [
@@ -56,6 +57,10 @@ export const salesReportRoutes: Routes = [
   {
     path: 'sales-by-region-tabular',
     component: SalesByRegionTabularComponent
+  },
+  {
+    path: 'sales-by-month',
+    component: SalesByMonthComponent
   }
 ];
 

--- a/apre-client/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apre-client/src/app/layouts/main-layout/main-layout.component.ts
@@ -307,6 +307,7 @@ export class MainLayoutComponent {
   salesReports = [
     { name: 'Sales by Region', url: '/reports/sales/sales-by-region' },
     { name: 'Sales by Region - Tabular', url: '/reports/sales/sales-by-region-tabular' },
+    { name: 'Sales by Month', url: '/reports/sales/sales-by-month' },
     // Add more reports as needed
   ];
 

--- a/apre-client/src/app/reports/sales/sales-by-month/sales-by-month.component.spec.ts
+++ b/apre-client/src/app/reports/sales/sales-by-month/sales-by-month.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SalesByMonthComponent } from './sales-by-month.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('SalesByMonthComponent', () => {
+  let component: SalesByMonthComponent;
+  let fixture: ComponentFixture<SalesByMonthComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, SalesByMonthComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SalesByMonthComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title "Sales by Month"', () => {
+    const compiled = fixture.nativeElement;
+    const titleElement = compiled.querySelector('h1');
+    expect(titleElement).toBeTruthy();
+    expect(titleElement.textContent).toContain('Sales by Month');
+  });
+
+  it('should initialize the monthForm with a null values', () => {
+    const monthControl = component.monthForm.controls['month'];
+    const yearControl = component.monthForm.controls['year'];
+
+    expect(monthControl.value).toBeNull();
+    expect(monthControl.valid).toBeFalse();
+
+    expect(yearControl.value).toBeNull();
+    expect(yearControl.valid).toBeFalse();
+  });
+
+  it('should not submit the form if no month or year are selected', () => {
+    spyOn(component, 'onSubmit').and.callThrough();
+
+    const compiled = fixture.nativeElement;
+    const submitButton = compiled.querySelector('.form__actions button');
+    submitButton.click();
+
+    expect(component.onSubmit).toHaveBeenCalled();
+    expect(component.monthForm.valid).toBeFalse();
+  });
+});

--- a/apre-client/src/app/reports/sales/sales-by-month/sales-by-month.component.ts
+++ b/apre-client/src/app/reports/sales/sales-by-month/sales-by-month.component.ts
@@ -1,0 +1,130 @@
+/**
+ * Author: Brandon Salvemini
+ * Date: 1 November 2024
+ * File: sales-by-month.component.ts
+ * Description: Sales by month component
+ * This component uses some code from the ChannelRatingByMonthComponent
+ */
+import { CommonModule, formatCurrency } from '@angular/common';
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TableComponent } from '../../../shared/table/table.component';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
+
+@Component({
+  selector: 'app-sales-by-month',
+  standalone: true,
+  imports: [ReactiveFormsModule, CommonModule, TableComponent],
+  template: `
+  <h1>Sales by Month</h1>
+  <div class="month-container">
+    <!-- Form code based on form from the ChannelRatingByMonthComponent  -->
+  <form class="form" [formGroup]="monthForm" (ngSubmit)="onSubmit()">
+  @if (errorMessage) {
+          <div class="message message--error">{{ errorMessage }} </div>
+        }
+
+        <div class="form__group">
+          <label class="label" for="month">Month</label>
+          <select class="select" formControlName="month" id="month" name="month">
+            <option value="1">January</option>
+            <option value="2">February</option>
+            <option value="3">March</option>
+            <option value="4">April</option>
+            <option value="5">May</option>
+            <option value="6">June</option>
+            <option value="7">July</option>
+            <option value="8">August</option>
+            <option value="9">September</option>
+            <option value="10">October</option>
+            <option value="11">November</option>
+            <option value="12">December</option>
+          </select>
+          <label for="year" class="label">Year</label>
+          <input type="number" name="year" id="year" formControlName="year" min="2000" max="2024">
+        </div>
+        <div class="form__actions">
+          <button class="button button--primary" type="submit">Submit</button>
+        </div>
+  </form>
+  @if (monthlySalesData.length > 0) {
+    <app-table
+          [title]="'Sales by Month'"
+          [data]="monthlySalesData"
+          [headers]="['Date', 'Salesperson', 'Product', 'Category', 'Channel', 'Customer', 'Region', 'Amount']"
+          [recordsPerPage]="10"
+          [sortableColumns]="['Date', 'Salesperson', 'Product', 'Category', 'Channel', 'Customer', 'Region', 'Amount']"
+          [headerBackground]="'default'">
+        </app-table>
+  }
+  </div>
+  `,
+  styles: `
+  .month-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .form, .chart-card {
+      width: 50%;
+      margin: 20px 0;
+    }
+
+    label[for=year] {
+    margin-top: 5px;
+    }
+    input#year {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 1em;
+    transition: border-color 0.3s ease;
+    background-color: white;
+    }`
+})
+export class SalesByMonthComponent {
+monthForm = this.fb.group({
+    month: [null, Validators.compose([Validators.required])],
+    year: [null, Validators.compose([Validators.required])]
+  });
+  monthlySalesData: any[] = []
+  errorMessage: string;
+
+  constructor(private http: HttpClient, private fb: FormBuilder, private cdr: ChangeDetectorRef) {
+    this.errorMessage = '';
+  }
+  onSubmit() {
+    if (this.monthForm.invalid) {
+      this.errorMessage = 'Please select a month and enter a year';
+      console.log(this.errorMessage);
+      return;
+    }
+
+    // Get the month and year from the form
+    const month = this.monthForm.controls['month'].value;
+    const year = this.monthForm.controls['year'].value;
+
+    this.http.get(`${environment.apiBaseUrl}/reports/sales/monthly?month=${month}&year=${year}`).subscribe({
+      next: (data: any) => {
+        this.monthlySalesData = data; // Set the monthlySalesData array to the data received
+        console.log('this.salesData: ', this.monthlySalesData);
+        for(let data of this.monthlySalesData) { // Set up table
+          data['Date'] = new Date (data['date']).toLocaleDateString(); // Format the date
+          data['Salesperson'] = data['salesperson'];
+          data['Product'] = data['product'];
+          data['Category'] = data['category'];
+          data['Channel'] = data['channel'];
+          data['Customer'] = data['customer'];
+          data['Region'] = data['region'];
+          data['Amount'] = formatCurrency(data['amount'], 'en-us', '$'); // Format the amount as USD currency
+        }
+
+        this.errorMessage = ''; // Reset error message
+      },
+      error: (err) => {
+        console.error('Error fetching monthly sales data:', err);
+      }
+    });
+  }
+}

--- a/apre-server/src/routes/reports/sales/index.js
+++ b/apre-server/src/routes/reports/sales/index.js
@@ -9,6 +9,7 @@
 
 const express = require('express');
 const { mongo } = require('../../../utils/mongo');
+const createError = require('http-errors');
 
 const router = express.Router();
 
@@ -76,6 +77,57 @@ router.get('/regions/:region', (req, res, next) => {
     console.error('Error getting sales data for region: ', err);
     next(err);
   }
+});
+
+/**
+ * @description
+ *
+ * GET /monthly/
+ *
+ * Fetches sales data for a specific month and year
+ *
+ * Example:
+ * fetch('monthly?month=9&year=2023')
+ *  .then(response => response.json())
+ *  .then(data => console.log(data));
+ */
+router.get('/monthly', (req, res, next) => {
+  // Get the month and year from the query string
+  let { month, year } = req.query;
+
+  // If the month or the year are not specified
+  if(!month || !year) {
+    return next(createError(400, 'Month and year are required')); // return 400 error with 'Month and year are required' message
+  }
+
+  // If the month is less than 1 or greater than 12
+  if(month < 1 || month > 12) {
+    return next(createError(400, 'Month must be a number between 1 and 12')); // return 400 error with 'Month must be a number 1 through 12' message
+  }
+
+  // JS month numbers start at zero, so the month number will be one off.
+  // Subtract one from the given month to compensate for this.
+  month = month - 1;
+
+  // Date for the first day of the given month
+  let firstOfTheMonth = new Date(year, month, 1);
+
+  // Date for the last day of the given month
+  // This was done with the help of this article: https://bobbyhadz.com/blog/javascript-get-first-day-of-month
+  let lastDayOfMonth = new Date(year, month + 1, 0);
+
+try {
+  // Get the records from the sales data collection from the first of the month to the last day of the month
+  // Data is sorted by date ascending, then converted to an array
+  mongo (async db => {
+    const monthlySalesData = await db.collection('sales').find({date: {$gte: firstOfTheMonth, $lte: lastDayOfMonth,}}).sort({ date: 1 }).toArray();
+    res.send(monthlySalesData);
+  })
+} catch (err) {
+  console.error('Error getting monthly sales data: ', err);
+  next(err);
+}
+
 });
 
 module.exports = router;

--- a/apre-server/test/routes/reports/sales/index.spec.js
+++ b/apre-server/test/routes/reports/sales/index.spec.js
@@ -143,3 +143,56 @@ describe('Apre Sales Report API - Sales by Region', () => {
     });
   });
 });
+
+// Test the monthly sales data report API
+describe('Apre Sales Report API - Monthly sales data', () => {
+  beforeEach(() => {
+    mongo.mockClear();
+  });
+
+// Test the monthly endpoint with missing parameters
+  it('should return 400 if month and/or year are missing', async () => {
+    // Make a request to the endpoint
+    const response = await request(app).get('/api/reports/sales/monthly');
+
+    // Assert the response
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: 'Month and year are required',
+      status: 400,
+      type: 'error'
+    });
+  });
+
+  // Test the monthly endpoint with an invalid month number
+  it('should return 400 if month is less than 1 or greater than 12', async () => {
+    // Make a request to the endpoint
+    const response = await request(app).get('/api/reports/sales/monthly?month=0&year=2023');
+
+    // Assert the response
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: 'Month must be a number between 1 and 12',
+      status: 400,
+      type: 'error'
+    });
+  });
+
+  it('should return 200 with an empty array if no sales data is found', async () => {
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        find: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        toArray: jest.fn().mockResolvedValue([])
+      };
+      await callback(db);
+    })
+
+    // Make a request to the endpoint
+    const response = await request(app).get('/api/reports/sales/monthly?month=9&year=2023');
+
+    expect(response.status).toBe(200); // Expect a 200 status code
+    expect(response.body).toEqual([]); // Expect the response body to match the expected data
+  });
+});


### PR DESCRIPTION
Added the monthly sales data API and SalesByMonthComponent for task M-062. 

I created a new API to fetch monthly sales data in apre-server/src/routes/reports/sales/index.js. My code was placed at the bottom of this file. The tests for this API are in apre-server/test/routes/reports/sales/index.spec.js, at the bottom of the file in their own test suite.

I created a new Angular component to retrieve and display monthly sales data. The component and it's tests are in apre-client/src/app/reports/sales/sales-by-month, in sales-by-month.component.ts and sales-by-month.component.spec.ts respectively.  A link to this new component was added to the salesReports array in the apre-client/src/app/layouts/main-layout/main-layout.component.ts file. A route for the component was also added to the app.routes.ts file.
