### PR TITLE
Add CSS class for the confirm dialog background overlay

### DIFF
--- a/apre-client/src/app/shared/confirm-dialog/confirm-dialog.component.ts
+++ b/apre-client/src/app/shared/confirm-dialog/confirm-dialog.component.ts
@@ -13,6 +13,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   standalone: true,
   imports: [],
   template: `
+    <div class="confirm-dialog-bg"></div> <!-- div for confirm dialog background -->
     <div class="confirm-dialog">
       <h1 class="confirm-dialog__title">{{ header }}</h1>
       <p class="confirm-dialog__message">{{ message }}</p>
@@ -23,6 +24,21 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
     </div>
   `,
   styles: `
+    /*
+    CSS for confirm-dialog-bg based on
+    https://www.w3schools.com/howto/howto_css_overlay.asp
+    */
+    .confirm-dialog-bg { /* Class for semi-transparent background overlay */
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(50, 50, 50, 0.75);
+      z-index: 2;
+    }
     .confirm-dialog {
       position: fixed;
       top: 50%;


### PR DESCRIPTION
I added a CSS class that added a semi-transparent background overlay behind the confirm dialog. On line 16 of confirm-dialog.component.ts, I added an empty standalone div with a CSS class for the background overlay, as well as a comment describing the line. On lines 27 to 41 confirm-dialog.component.ts I added a comment to the article I based the CSS on, the actual CSS class for the semi-transparent background overlay, as well as a comment describing the purpose of the CSS class.