### PR TITLE
Add regional agent performance API and Angular component for task_M-085

### DIFF
--- a/apre-client/src/app/app.routes.ts
+++ b/apre-client/src/app/app.routes.ts
@@ -32,6 +32,7 @@ import { SalesByProductComponent } from './reports/sales/sales-by-product/sales-
 import { SalesBySalespersonComponent } from './reports/sales/sales-by-salesperson/sales-by-salesperson.component';
 import { SalesByYearTabularComponent } from './reports/sales/sales-by-year-tabular/sales-by-year-tabular.component';
 import { SalesByMonthComponent } from './reports/sales/sales-by-month/sales-by-month.component';
+import { AgentPerformanceByRegionComponent } from './reports/agent-performance/agent-performance-by-region/agent-performance-by-region.component';
 
 // Export user-management routes
 export const userManagementRoutes: Routes = [
@@ -97,6 +98,10 @@ export const agentPerformanceRoutes: Routes = [
   {
     path: 'call-duration-by-date-range',
     component: CallDurationByDateRangeComponent
+  },
+  {
+    path: 'agent-performance-by-region',
+    component: AgentPerformanceByRegionComponent
   }
 ];
 

--- a/apre-client/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apre-client/src/app/layouts/main-layout/main-layout.component.ts
@@ -319,7 +319,8 @@ export class MainLayoutComponent {
   ];
 
   agentPerformanceReports = [
-    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' }
+    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' },
+    { name: 'Performance by Region', url: '/reports/agent-performance/agent-performance-by-region' }
     // Add more reports as needed
   ];
 

--- a/apre-client/src/app/reports/agent-performance/agent-performance-by-region/agent-performance-by-region.component.spec.ts
+++ b/apre-client/src/app/reports/agent-performance/agent-performance-by-region/agent-performance-by-region.component.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Author: Brandon Salvemini
+ * Date: 11/8/2024
+ * File: agent-performance-by-region.component.spec.ts
+ * Description: Test file for the agent performance by region component
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AgentPerformanceByRegionComponent } from './agent-performance-by-region.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('AgentPerformanceByRegionComponent', () => {
+  let component: AgentPerformanceByRegionComponent;
+  let fixture: ComponentFixture<AgentPerformanceByRegionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, AgentPerformanceByRegionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AgentPerformanceByRegionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title "Agent Performance by Region"', () => {
+    const compiled = fixture.nativeElement;
+    const titleElement = compiled.querySelector('h1');
+    expect(titleElement).toBeTruthy();
+    expect(titleElement.textContent).toContain('Agent Performance by Region');
+  });
+
+  it('should not submit form is no region is selected', () => {
+    spyOn(component, 'onSubmit').and.callThrough();
+
+    const compiled = fixture.nativeElement;
+    const submitBtn = compiled.querySelector('.form__actions button')
+    submitBtn.click();
+
+    expect(component.onSubmit).toHaveBeenCalled();
+    expect(component.regionForm.valid).toBeFalse;
+  });
+
+  it('should initialize the regionForm with a null value', () => {
+    const regionControl = component.regionForm.controls['region'];
+    expect(regionControl.value).toBeNull();
+    expect(regionControl.valid).toBeFalse();
+  });
+});

--- a/apre-client/src/app/reports/agent-performance/agent-performance-by-region/agent-performance-by-region.component.ts
+++ b/apre-client/src/app/reports/agent-performance/agent-performance-by-region/agent-performance-by-region.component.ts
@@ -1,0 +1,107 @@
+/**
+ * Author: Brandon Salvemini
+ * Date: 11/8/2024
+ * File: agent-performance-by-region.component.ts
+ * Description: Agent performance by region component
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { environment } from '../../../../environments/environment';
+import { TableComponent } from '../../../shared/table/table.component';
+
+@Component({
+  selector: 'app-agent-performance-by-region',
+  standalone: true,
+  imports: [ReactiveFormsModule, TableComponent],
+  template: `
+  <h1>Agent Performance by Region</h1>
+    <div class="region-container">
+      <form class="form" [formGroup]="regionForm" (ngSubmit)="onSubmit()">
+        <div class="form__group">
+          <label class="label" for="region">Region<span class="required">*</span></label>
+          <select class="select" formControlName="region" id="region" name="region">
+            @for(region of regions; track region) {
+              <option value="{{ region }}">{{ region }}</option>
+            }
+          </select>
+        </div>
+        <div class="form__actions">
+          <button class="button button--primary" type="submit">Submit</button>
+        </div>
+      </form>
+      @if (performanceDataByRegionData.length > 0) {
+        <app-table
+          [title]="'Agent Performance by Region'"
+          [data]="performanceDataByRegionData"
+          [headers]="['Date', 'Region', 'Agent', 'Team', 'Call Duration', 'Resolution Time', 'Feedback']"
+          [recordsPerPage]="10"
+          [sortableColumns]="['Date', 'Team', 'Call Duration', 'Resolution Time']"
+          [headerBackground]="'default'">
+        </app-table>
+      }
+  `,
+  styles: [`
+    .region-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .form, .chart-card {
+      width: 50%;
+      margin: 20px 0;
+    }
+  `]
+})
+export class AgentPerformanceByRegionComponent {
+  regions: string[] = [];
+  performanceDataByRegionData: any[] = [];
+
+  regionForm = this.fb.group({
+    region: [null, Validators.compose([Validators.required])]
+  });
+
+  constructor(
+    private http: HttpClient,
+    private fb: FormBuilder
+  ) {
+    this.http.get(`${environment.apiBaseUrl}/reports/agent-performance/region/regions`).subscribe({ // Fetch the regions on page load
+      next: (data: any) => {
+        this.regions = data;
+      },
+      error: (err) => {
+        console.error('Error fetching regions:', err);
+      }
+    });
+  }
+
+  onSubmit() {
+    const region = this.regionForm.controls['region'].value;
+    this.http.get(`${environment.apiBaseUrl}/reports/agent-performance/region/${region}`).subscribe({
+      next: (data: any) => {
+        this.performanceDataByRegionData = data;
+        console.log(this.performanceDataByRegionData);
+
+        for(let data of this.performanceDataByRegionData) { // Set up table
+          data['Date'] = new Date (data['date']).toLocaleDateString(); // Format the date
+          data['Region'] = data['region'];
+          data['Team'] = data['team'];
+          data['Call Duration'] = data['callDuration'];
+          data['Resolution Time'] = data['resolutionTime'];
+          data['Feedback'] = data['customerFeedback'];
+
+          if (data['agentDetails'].name === undefined) { // if the agentDetails.name is undefined
+            data['Agent'] = 'Unknown'; // Set agent name to unknown
+          } else {
+            data['Agent'] = data['agentDetails'].name; // Get agent name from agentDetails array
+          }
+        }
+      },
+      error: (err) => {
+        console.error('Error fetching agent performance data: ', err);
+      },
+    });
+  }
+
+}

--- a/apre-server/src/app.js
+++ b/apre-server/src/app.js
@@ -21,6 +21,7 @@ const dashboardRouter = require('./routes/dashboard');
 const salesReportsRouter = require('./routes/reports/sales');
 const agentPerformanceReportsRouter = require('./routes/reports/agent-performance');
 const customerFeedbackReportsRouter = require('./routes/reports/customer-feedback');
+const agentDataByRegionRouter = require('./routes/reports/agent-performance/agent-data-by-region');
 
 // Variable declaration for the express app
 let app = express();
@@ -46,6 +47,7 @@ app.use('/api/security', securityRouter);
 app.use('/api/dashboard', dashboardRouter);
 app.use('/api/reports/sales', salesReportsRouter);
 app.use('/api/reports/agent-performance', agentPerformanceReportsRouter);
+app.use('/api/reports/agent-performance/region', agentDataByRegionRouter);
 app.use('/api/reports/customer-feedback', customerFeedbackReportsRouter);
 
 // Use the error handling middleware

--- a/apre-server/src/routes/reports/agent-performance/agent-data-by-region.js
+++ b/apre-server/src/routes/reports/agent-performance/agent-data-by-region.js
@@ -1,0 +1,95 @@
+/**
+ * Author: Brandon Salvemini
+ * Date: 11/7/2024
+ * File: agent-data-by-region.js
+ * Description: Route file for fetching agent performance data by region
+ */
+'use strict';
+
+const express = require('express');
+const { mongo } = require('../../../utils/mongo');
+
+const router = express.Router();
+
+/**
+ * @description
+ *
+ * GET /regions
+ *
+ * Fetches a list of distinct agent performance regions.
+ *
+ * Example:
+ * fetch('/regions')
+ *  .then(response => response.json())
+ *  .then(data => console.log(data));
+ */
+router.get('/regions', (req, res, next) => {
+  try {
+    mongo (async db => {
+      const regions = await db.collection('agentPerformance').distinct('region');
+      res.send(regions);
+    }, next);
+  } catch (err) {
+    console.error('Error getting regions: ', err);
+    next(err);
+  }
+});
+
+/**
+ * @description
+ *
+ * GET /:region
+ *
+ * Fetches agent performance data for a given region
+ *
+ * Example:
+ * fetch('/region/Australia')
+ *  .then(response => response.json())
+ *  .then(data => console.log(data));
+ */
+router.get('/:region', function(req, res, next) {
+  try {
+    mongo (async db => {
+      const agentPerformanceReportByRegion = await db.collection('agentPerformance').aggregate([
+        {
+          '$match': {
+            'region': req.params.region // match on the given region
+          }
+        }, {
+          '$lookup': { // lookup the agent details from the agents collection using the agentID field
+            'from': 'agents',
+            'localField': 'agentId',
+            'foreignField': 'agentId',
+            'as': 'agentDetails'
+          }
+        }, {
+          '$addFields': {
+            'agentDetails': {
+              '$arrayElemAt': [
+                '$agentDetails', 0 // get the first entry from the agentDetails array
+              ]
+            }
+          }
+        }, {
+          '$addFields': {
+            'agentDetails': {
+              '$ifNull': [
+                '$agentDetails', {} // if agentDetails is null, set it to an empty object
+              ]
+            }
+          }
+        }, {
+          '$unset': [
+            '_id', 'performanceMetrics', 'supervisorId' // Remove '_id', 'performanceMetrics', and 'supervisorId' from the result
+          ]
+        }
+      ]).toArray();
+      res.send(agentPerformanceReportByRegion);
+    }, next);
+  } catch (err) {
+    console.error('Error getting agent performance data for region: ', err);
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/apre-server/test/routes/reports/agent-performance/agent-data-by-region.spec.js
+++ b/apre-server/test/routes/reports/agent-performance/agent-data-by-region.spec.js
@@ -1,0 +1,67 @@
+/**
+ * Author: Brandon Salvemini
+ * Date: 7 November 2024
+ * File: agent-data-by-region.spec.js
+ * Description: Test the agent performance data by region API
+ */
+
+// Require the modules
+const request = require('supertest');
+const app = require('../../../../src/app');
+const { mongo } = require('../../../../src/utils/mongo');
+
+jest.mock('../../../../src/utils/mongo');
+
+// Test the agent performance data by region API
+describe('Apre Agent Performance data by region API', () => {
+  beforeEach(() => {
+    mongo.mockClear();
+  });
+
+  // Test the region/regions endpoint
+  it('should fetch a list of distinct agent performance regions', async () => {
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockResolvedValue(['Africa','Asia','Australia','Europe','North America','South America'])
+      };
+      await callback(db);
+    });
+
+    const response = await request(app).get('/api/reports/agent-performance/region/regions'); // Send a GET request to the region/regions endpoint
+
+    expect(response.status).toBe(200); // Expect a 200 status code
+    expect(response.body).toEqual(['Africa','Asia','Australia','Europe','North America','South America']); // Expect the response body to match the expected data
+  });
+
+  it('should return 404 for an invalid endpoint', async () => {
+    const response = await request(app).get('/api/reports/agent-performance/region/'); // Send a GET request to an invalid endpoint
+    expect(response.status).toBe(404);
+    // Expect the response data to equal the expected data
+    expect(response.body).toEqual({
+      message: 'Not Found',
+      status: 404,
+      type: 'error'
+    });
+  });
+
+  it('should return 200 and an empty array if no agent performance data is found for the region', async () => {
+    // Mock the MongoDB implementation
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        aggregate: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([])
+        })
+      };
+      await callback(db);
+    });
+
+    // Make a request to the endpoint
+    const response = await request(app).get('/api/reports/agent-performance/region/Australiaa');
+
+    // Assert the response
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+});


### PR DESCRIPTION
Added the regional agent performance API and AgentPerformanceByRegionComponent for task_M-085.

I created a new API to fetch agent performance data by region in `apre-server/src/routes/reports/agent-performance/agent-data-by-region.js`. The corresponding test file is `apre-server/test/routes/reports/agent-performance/agent-data-by-region.spec.js`. Both were created in a new file as we discussed during Wednesday's class.

I created an Angular component to retrieve and display regional agent performance data. The component and it's tests are in `apre-client/src/app/reports/agent-performance/agent-performance-by-region`, in `agent-performance.component.ts` and `agent-performance.component.spec.ts` respectively. A link to this new component was added to the `agentPerformanceReports` array in the `apre-client/src/app/layouts/main-layout/main-layout.component.ts` file. A route for the component was also added to the `app.routes.ts` file.

I created two APIs for this task. One gets the distinct regions, which is used to populate the select in the AgentPerformanceByRegionComponent. The second API is the one that actually fetches the agent performance data by region.