### PR TITLE
M088 report performance data by metrictype

### DIFF
--- a/apre-client/src/app/app.routes.ts
+++ b/apre-client/src/app/app.routes.ts
@@ -32,6 +32,8 @@ import { SalesByProductComponent } from './reports/sales/sales-by-product/sales-
 import { SalesBySalespersonComponent } from './reports/sales/sales-by-salesperson/sales-by-salesperson.component';
 import { SalesByYearTabularComponent } from './reports/sales/sales-by-year-tabular/sales-by-year-tabular.component';
 import { SalesByMonthComponent } from './reports/sales/sales-by-month/sales-by-month.component';
+//import agent-performance related reports
+import { PerformanceByMetricComponent } from './reports/agent-performance/performance-by-metric/performance-by-metric.component';
 
 // Export user-management routes
 export const userManagementRoutes: Routes = [
@@ -97,6 +99,10 @@ export const agentPerformanceRoutes: Routes = [
   {
     path: 'call-duration-by-date-range',
     component: CallDurationByDateRangeComponent
+  },
+  {
+    path: 'performance-by-metric',
+    component: PerformanceByMetricComponent
   }
 ];
 

--- a/apre-client/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apre-client/src/app/layouts/main-layout/main-layout.component.ts
@@ -319,8 +319,10 @@ export class MainLayoutComponent {
   ];
 
   agentPerformanceReports = [
-    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' }
+    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' },
     // Add more reports as needed
+    // Added link for Performance by Metric
+    { name: 'Performance by Metric', url: '/reports/agent-performance/performance-by-metric' },
   ];
 
   customerFeedbackReports = [

--- a/apre-client/src/app/reports/agent-performance/performance-by-metric/performance-by-metric.component.spec.ts
+++ b/apre-client/src/app/reports/agent-performance/performance-by-metric/performance-by-metric.component.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PerformanceByMetricComponent } from './performance-by-metric.component';
+import { By } from '@angular/platform-browser';
+
+// Test suite for the PerformanceByMetric component
+describe('PerformanceByMetricComponent', () => {
+  let component: PerformanceByMetricComponent;
+  let fixture: ComponentFixture<PerformanceByMetricComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, PerformanceByMetricComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PerformanceByMetricComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // Default test that the component should be created
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Test that the title is properly displayed
+  it('should display the title "Agent Performance by Metric"', () => {
+    const compiled = fixture.nativeElement;
+    const titleElement = compiled.querySelector('h1');
+
+    expect(titleElement).toBeTruthy();
+    expect(titleElement.textContent).toContain('Agent Performance by Metric');
+  });
+
+  // Test that the performance metric select element has a default value of null
+  it('should default to a null value for the performance metric select element', () => {
+    // Create a reference to the perfMetric select element
+    const perfMetricSelect = component.perfMetricForm.controls['perfMetric'];
+
+    // Expect the value to be null
+    expect(perfMetricSelect.value).toBeNull();
+    // Expect the perfMetric control to be invalid
+    expect(perfMetricSelect.valid).toBeFalse();
+  });
+
+  // Test that the form is not submitted if there is no selected metric
+  it('should not submit if no metric is selected', () => {
+    // Create a spy on the onSubmit function
+    spyOn(component, 'onSubmit').and.callThrough();
+
+    // Create a reference to the component's element
+    const compiled = fixture.nativeElement;
+
+    // Create a reference to the form's submit button
+    const submitButton = compiled.querySelector('.form__actions button');
+
+    // Simulate submitting
+    submitButton.click();
+
+    // Expect onSubmit to have been called
+    expect(component.onSubmit).toHaveBeenCalled();
+    // Expect the form to be invalid since we did not select a salesperson
+    expect(component.perfMetricForm.valid).toBeFalse();
+  });
+});

--- a/apre-client/src/app/reports/agent-performance/performance-by-metric/performance-by-metric.component.ts
+++ b/apre-client/src/app/reports/agent-performance/performance-by-metric/performance-by-metric.component.ts
@@ -1,0 +1,104 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { environment } from '../../../../environments/environment';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ChartComponent } from '../../../shared/chart/chart.component';
+
+@Component({
+  selector: 'app-performance-by-metric',
+  standalone: true,
+  imports: [ReactiveFormsModule, ChartComponent],
+  template: `
+    <h1>Agent Performance by Metric</h1>
+    <div class="metric-container">
+      <form class="form" [formGroup]="perfMetricForm" (ngSubmit)="onSubmit()">
+        <div class="form__group">
+          <label class="label" for="perfMetric">Performance Metric<span class="required">*</span></label>
+          <select class="select" formControlName="perfMetric" id="perfMetric" name="perfMetric">
+            @for(pMetric of perfMetrics; track pMetric) {
+              <option value="{{ pMetric }}">{{ pMetric }}</option>
+            }
+          </select>
+        </div>
+        <div class="form__actions">
+          <button class="button button--secondary" type="submit">Submit</button>
+        </div>
+      </form>
+
+      @if (agents.length && performanceTotals.length) {
+        <div class="card chart-card">
+          <app-chart
+            [type]="'bar'"
+            [label]="this.reportTitle"
+            [data]="this.performanceTotals"
+            [labels]="this.agents">
+          </app-chart>
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    .metric-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .form, .chart-container {
+      width: 50%;
+      margin: 0 auto;
+    }
+
+    .chart-card {
+      width: 100%;
+      margin: 20px 0;
+    }
+  `
+})
+export class PerformanceByMetricComponent {
+  // Create variables
+  //TODO: Add new performance metrics to this array as needed.
+  perfMetrics: string[] = ["Customer Satisfaction", "Sales Conversion"]; // Array of performance metrics
+  selectedPerfMetric: string | null = null; // Selected performance metric is set to null
+  reportTitle: string = ''; // Report title, populated and set in the submit function
+  agents: string[] = [];
+  performanceTotals: number[] = [];
+  performanceData: any[] = [];
+
+  // Create a form group array
+  perfMetricForm = this.fb.group({
+    perfMetric: [null, Validators.compose([Validators.required])]
+  });
+
+  // Constructor to handle initial setup and dependency injection
+  constructor(private http: HttpClient, private fb: FormBuilder) {}
+
+  /**
+   * @description
+   *
+   * onSubmit function to handle form action to generate a report.
+   * This should not execute if there is no selected performance metric
+   */
+  onSubmit() {
+    // Get the selected performance metric
+    this.selectedPerfMetric = this.perfMetricForm.controls['perfMetric'].value;
+
+    // Query the database for the report data
+    this.http.get(`${environment.apiBaseUrl}/reports/agent-performance/performance-by-metric/${this.selectedPerfMetric}`).subscribe({
+      next: (data: any) => {
+        this.performanceData = data;
+        // Map arrays from the data to the variables
+        this.agents = this.performanceData[0].agentNames;
+        this.performanceTotals = this.performanceData[0].performanceTotals;
+
+        // Construct the report title
+        this.reportTitle = "Performance by Metric - " + this.selectedPerfMetric;
+
+        console.log('agents:', this.agents);
+        console.log('performance totalsL ', this.performanceTotals);
+      },
+      error: (err) => {
+        console.error('Error fetching sales data:', err);
+      }
+    });
+  }
+}

--- a/apre-server/test/routes/reports/agent-performance/performance-by-metric.spec.js
+++ b/apre-server/test/routes/reports/agent-performance/performance-by-metric.spec.js
@@ -1,0 +1,157 @@
+/**
+ * Author: Sheldon Skaggs
+ * Date: 11/082024
+ * File: performance-by-metric.spec.js
+ * Description: Test the agent performance by metric report api
+ */
+
+// Require the modules
+const request = require('supertest');
+const app = require('../../../../src/app');
+const { mongo } = require('../../../../src/utils/mongo');
+
+// Mock database
+jest.mock('../../../../src/utils/mongo');
+
+// Test suite for the Agent Performance by Metric Report API
+describe('APRE Agent Performance by Metric Suite', () => {
+  // Clear the mock before each test
+  beforeEach(() => {
+    mongo.mockClear();
+  });
+
+  // Test accessing an invalid endpoint
+  it('should return 404 for an invalid endpoint', async () => {
+    // Send a GET request to an invalid endpoint
+    const response = await request(app).get('/api/reports/agent-performance/not-an-endpoint');
+
+    // Expect a 404 status code
+    expect(response.status).toBe(404);
+    // Expect the response body to match the expected data
+    expect(response.body).toEqual({
+      message: 'Not Found',
+      status: 404,
+      type: 'error'
+    });
+  });
+
+  // Test the performance-by-metric endpoint for a metric that does not exist
+  it('should return a 200 status with no metric values for each agent for a metric that does not exist', async () => {
+    // Create a mock of the expected return data
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        aggregate: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            {
+              "agentId": 1000,
+              "agentName": "Jon Anderson",
+              "metricName": "",
+              "metricValue": 0,
+            },
+            {
+              "agentId": 1002,
+              "agentName": "Rindy Ross",
+              "metricName": "",
+              "metricValue": 0,
+            },
+            {
+              "agentId": 1,
+              "agentName": "Tom Scholz",
+              "metricName": "",
+              "metricValue": 0,
+            }
+          ])
+        })
+      };
+      await callback(db);
+    });
+
+    // Send a GET request to the reports/agent-performance/performance-by-metric/:metricName endpoint using the value of InVaLiD
+    const response = await request(app).get('/api/reports/agent-performance/performance-by-metric/InVaLiD');
+
+    // Expect the status code to be 200
+    expect(response.status).toBe(200);
+    // Expect the response body to match the expected data
+    expect(response.body).toEqual([
+      {
+        "agentId": 1000,
+        "agentName": "Jon Anderson",
+        "metricName": "",
+        "metricValue": 0,
+      },
+      {
+        "agentId": 1002,
+        "agentName": "Rindy Ross",
+        "metricName": "",
+        "metricValue": 0,
+      },
+      {
+        "agentId": 1,
+        "agentName": "Tom Scholz",
+        "metricName": "",
+        "metricValue": 0,
+      }
+    ]);
+  });
+
+  // Test the performance-by-metric endpoint for a valid metric
+  it('should return a 200 status with metric values for each agent for a given metric', async () => {
+    // Create a mock of the expected return data
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        aggregate: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            {
+              "agentId": 1000,
+              "agentName": "Jon Anderson",
+              "metricName": "Customer Satisfaction",
+              "metricValue": 80,
+            },
+            {
+              "agentId": 1002,
+              "agentName": "Rindy Ross",
+              "metricName": "Customer Satisfaction",
+              "metricValue": 100,
+            },
+            {
+              "agentId": 1,
+              "agentName": "Tom Scholz",
+              "metricName": "Customer Satisfaction",
+              "metricValue": 90,
+            }
+          ])
+        })
+      };
+      await callback(db);
+    });
+
+    // Send a GET request to the reports/agent-performance/performance-by-metric/:metricName endpoint using the value of Customer Satisfaction
+    const response = await request(app).get('/api/reports/agent-performance/performance-by-metric/Customer Satisfaction');
+
+    // Expect the status code to be 200
+    expect(response.status).toBe(200);
+    // Expect the response body to match the expected data
+    expect(response.body).toEqual([
+      {
+        "agentId": 1000,
+        "agentName": "Jon Anderson",
+        "metricName": "Customer Satisfaction",
+        "metricValue": 80,
+      },
+      {
+        "agentId": 1002,
+        "agentName": "Rindy Ross",
+        "metricName": "Customer Satisfaction",
+        "metricValue": 100,
+      },
+      {
+        "agentId": 1,
+        "agentName": "Tom Scholz",
+        "metricName": "Customer Satisfaction",
+        "metricValue": 90,
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
# M-088 Report of Performance Data by Metric Type
I created an API to return data related to agent performance by metric type. We only have two metric types at this time so those are hard coded. I used the //TODO: to help call attention should we need to add more metrics.
## Files Modified
### apre-server

- src/routes/reports/agent-performance/index.js
- test/routes/reports/agent-performance/performance-by-metric

### apre-client

- src/app/app.routes.ts
- layouts/main-layout/main-layout.component.ts
- reports/agent-performance/performance-by-metric/performance-by-metric.component.spec.ts
- reports/agent-performance/performance-by-metric/performance-by-metric.component.ts