### PR TITLE
feat(apre): add an API to fetch agent performance data by supervisor

### DIFF
--- a/apre-client/src/app/app.routes.ts
+++ b/apre-client/src/app/app.routes.ts
@@ -32,6 +32,7 @@ import { SalesByProductComponent } from './reports/sales/sales-by-product/sales-
 import { SalesBySalespersonComponent } from './reports/sales/sales-by-salesperson/sales-by-salesperson.component';
 import { SalesByYearTabularComponent } from './reports/sales/sales-by-year-tabular/sales-by-year-tabular.component';
 import { SalesByMonthComponent } from './reports/sales/sales-by-month/sales-by-month.component';
+import { AgentPerformanceBySupervisorComponent } from './reports/agent-performance/agent-performance-by-supervisor/agent-performance-by-supervisor.component';
 
 // Export user-management routes
 export const userManagementRoutes: Routes = [
@@ -97,6 +98,10 @@ export const agentPerformanceRoutes: Routes = [
   {
     path: 'call-duration-by-date-range',
     component: CallDurationByDateRangeComponent
+  },
+  {
+    path: 'agent-performance-by-supervisor',
+    component: AgentPerformanceBySupervisorComponent
   }
 ];
 

--- a/apre-client/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apre-client/src/app/layouts/main-layout/main-layout.component.ts
@@ -319,7 +319,8 @@ export class MainLayoutComponent {
   ];
 
   agentPerformanceReports = [
-    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' }
+    { name: 'Call Duration by Date Range', url: '/reports/agent-performance/call-duration-by-date-range' },
+    { name: 'Agent Performance by Supervisor', url: '/reports/agent-performance/agent-performance-by-supervisor' }
     // Add more reports as needed
   ];
 

--- a/apre-client/src/app/reports/agent-performance/agent-performance-by-supervisor/agent-performance-by-supervisor.component.spec.ts
+++ b/apre-client/src/app/reports/agent-performance/agent-performance-by-supervisor/agent-performance-by-supervisor.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AgentPerformanceBySupervisorComponent } from './agent-performance-by-supervisor.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('AgentPerformanceBySupervisorComponent', () => {
+  let component: AgentPerformanceBySupervisorComponent;
+  let fixture: ComponentFixture<AgentPerformanceBySupervisorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, AgentPerformanceBySupervisorComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AgentPerformanceBySupervisorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Test the title "Agent Performance By Supervisor" is displayed.
+  it('should display the title "Agent Performance By Supervisor"', () => {
+    const compiled = fixture.nativeElement;
+    const titleElement = compiled.querySelector('h1');
+    expect(titleElement).toBeTruthy();
+    expect(titleElement.textContent).toContain('Agent Performance By Supervisor');
+  });
+
+  // Test that the supervisorForm is initialized with null values.
+  it('should initialize the supervisorForm with null values', () => {
+    const supervisorControl = component.supervisorForm.controls['supervisor'];
+
+    expect(supervisorControl.value).toBeNull();
+    expect(supervisorControl.valid).toBeFalse();
+  });
+
+  // Test that the form should not be submit if no supervisor has been selected.
+  it('should not submit the form if no supervisor is selected', () => {
+    spyOn(component, 'onSubmit').and.callThrough();
+
+    const compiled = fixture.nativeElement;
+    const submitButton = compiled.querySelector('.form__actions button');
+    submitButton.click();
+
+    expect(component.onSubmit).toHaveBeenCalled();
+    expect(component.supervisorForm.valid).toBeFalse();
+  });
+});

--- a/apre-client/src/app/reports/agent-performance/agent-performance-by-supervisor/agent-performance-by-supervisor.component.ts
+++ b/apre-client/src/app/reports/agent-performance/agent-performance-by-supervisor/agent-performance-by-supervisor.component.ts
@@ -1,0 +1,110 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ChartComponent } from '../../../shared/chart/chart.component';
+import { environment } from '../../../../environments/environment';
+
+@Component({
+  selector: 'app-agent-performance-by-supervisor',
+  standalone: true,
+  imports: [ReactiveFormsModule, ChartComponent],
+  template: `
+    <h1>Agent Performance By Supervisor</h1>
+    <div class="supervisor-container">
+      <form class="form" [formGroup]="supervisorForm" (ngSubmit)="onSubmit()">
+        <div class="form__group">
+          <label class="label" for="supervisor">Supervisor ID<span class="required">*</span></label>
+          <select class="select" formControlName="supervisor" id="supervisor" name="supervisor">
+            @for(supervisor of supervisors; track supervisor) {
+              <option value="{{ supervisor }}">{{ supervisor }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="form__actions">
+          <button class="button button--primary" type="submit" title="Click to fetch Data">Submit</button>
+        </div>
+      </form>
+
+      <br />
+      @if (showChart) {
+        <div class="card chart-card">
+          <app-chart
+            [type]="'bar'"
+            [label]="'Agent Performance'"
+            [data]="resolutionTime"
+            [labels]="agents">
+          </app-chart>
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    .supervisor-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .form, .chart-card {
+      width: 50%;
+      margin: 20px 0;
+    }
+  `
+})
+export class AgentPerformanceBySupervisorComponent implements AfterViewInit {
+  supervisors: string[] = []; // Initially empty
+  resolutionTime: number[] = []; // Initially empty
+  agents: string[] = []; // Initially empty
+  showChart: boolean = false; // Initially hidden
+
+  supervisorForm = this.fb.group({
+    supervisor: [null, Validators.compose([Validators.required])]
+  });
+
+  constructor(
+    private http: HttpClient,
+    private fb: FormBuilder,
+    private cdr: ChangeDetectorRef
+  ) {
+    // Query to get the supervisors
+    this.http.get(`${environment.apiBaseUrl}/reports/agent-performance/agent-performance-by-supervisor`).subscribe({
+      next: (data: any) => {
+        this.supervisors = data;
+      },
+      error: (err) => {
+        console.error('Error fetching supervisors:', err);
+      }
+    });
+  }
+
+  ngAfterViewInit(): void {
+    // No need to create chart here, it will be handled by ChartComponent
+  }
+
+  onSubmit() {
+    // Get the value ​​of the field in the form
+    const supervisor = this.supervisorForm.controls['supervisor'].value;
+
+    // Check if there is any value in the supervisor field
+    if(supervisor) {
+      // Query that finds sales associated with the obtained supervisor
+      this.http.get(`${environment.apiBaseUrl}/reports/agent-performance/agent-performance-by-supervisor/${supervisor}`).subscribe({
+        next: (data: any) => {
+          // Set the values obtained
+          this.resolutionTime = data[0].resolutionsTime;
+          this.agents = data[0].agents;
+        },
+        error: (error: any) => {
+          console.error('Error fetching agent performance by supervisor data:', error);
+        },
+        complete: () => {
+          this.showChart = true; // Show chart after fetching data
+        }
+      });
+    } else {
+      // If there is no value in the supervisor field, an alert is generated to prompt the user to select one.
+      alert('Please select a supervisor.');
+    }
+  }
+
+}

--- a/apre-server/src/app.js
+++ b/apre-server/src/app.js
@@ -20,6 +20,7 @@ const securityRouter = require('./routes/security');
 const dashboardRouter = require('./routes/dashboard');
 const salesReportsRouter = require('./routes/reports/sales');
 const agentPerformanceReportsRouter = require('./routes/reports/agent-performance');
+const agentPerformanceBySupervisorReportRouter = require('./routes/reports/agent-performance/agent-performance-by-supervisor');
 const customerFeedbackReportsRouter = require('./routes/reports/customer-feedback');
 
 // Variable declaration for the express app
@@ -46,6 +47,7 @@ app.use('/api/security', securityRouter);
 app.use('/api/dashboard', dashboardRouter);
 app.use('/api/reports/sales', salesReportsRouter);
 app.use('/api/reports/agent-performance', agentPerformanceReportsRouter);
+app.use('/api/reports/agent-performance', agentPerformanceBySupervisorReportRouter);
 app.use('/api/reports/customer-feedback', customerFeedbackReportsRouter);
 
 // Use the error handling middleware

--- a/apre-server/src/routes/reports/agent-performance/agent-performance-by-supervisor.js
+++ b/apre-server/src/routes/reports/agent-performance/agent-performance-by-supervisor.js
@@ -1,0 +1,114 @@
+/**
+ * Author: Diana Ruiz Garcia
+ * Date: 11/09/24
+ * File: agent-performance-by-supervisor.js
+ * Description: Apre agent performance API for the agent performance report
+ * by supervisor.
+ */
+'use strict';
+
+const express = require('express');
+const { mongo } = require('../../../utils/mongo');
+const createError = require('http-errors');
+
+const ObjectId = require('mongodb').ObjectId; // Import ObjectId
+
+const router = express.Router();
+
+/**
+ * @description
+ *
+ * GET /agent-performance-by-supervisor
+ *
+ * Fetches a list of distinct agent performance supervisors.
+ *
+ * Example:
+ * fetch('/agent-performance-by-supervisor')
+ *  .then(response => response.json())
+ *  .then(data => console.log(data));
+ */
+router.get('/agent-performance-by-supervisor', (req, res, next) => {
+  try {
+    mongo (async db => {
+      const supervisors = await db.collection('agentPerformance').distinct('supervisorId');
+      res.send(supervisors);
+    }, next);
+  } catch (err) {
+    console.error('Error getting supervisors: ', err);
+    next(err);
+  }
+});
+
+/**
+ * @description
+ *
+ * GET /agent-performance-by-supervisor/:supervisorId
+ *
+ * Fetches agent performance data for a specific supervisor.
+ *
+ * Example:
+ * fetch('/agent-performance-by-supervisor/650c1f1e1c9d440000a1b1c3')
+ *  .then(response => response.json())
+ *  .then(data => console.log(data));
+ */
+router.get('/agent-performance-by-supervisor/:supervisorId', (req, res, next) => {
+  try {
+    const supervisorId = req.params.supervisorId;
+
+    if (!supervisorId.match(/^[0-9a-fA-F]{24}$/)) {
+      return next(createError(400, 'Supervisor ID is required'));
+    }
+
+    console.log('Fetching agent performance report for supervisor:', supervisorId);
+
+    mongo (async db => {
+      const agentPerformanceReportBySupervisor = await db.collection('agentPerformance').aggregate([
+        { $match: { supervisorId: new ObjectId(supervisorId) }},
+        {
+          $lookup: {
+            from: 'agents',
+            localField: 'agentId',
+            foreignField: 'agentId',
+            as: 'agentDetails'
+          }
+        },
+        {
+          $unwind: '$agentDetails'
+        },
+        {
+          $group: {
+            _id: '$agentDetails.name',
+            totalResolutionTime: { $sum: '$resolutionTime'}
+          }
+        },
+        {
+          $project: {
+            _id: 0,
+            agent: '$_id',
+            resolutionTime: '$totalResolutionTime'
+          }
+        },
+        {
+          $group: {
+            _id: null,
+            agents: { $push: '$agent' },
+            resolutionsTime: { $push: '$resolutionTime' }
+          }
+        },
+        {
+          $project: {
+            _id: 0,
+            agents: 1,
+            resolutionsTime: 1
+          }
+        }
+      ]).toArray();
+      res.send(agentPerformanceReportBySupervisor);
+    }, next);
+  } catch (err) {
+    console.error('Error getting agent performance data for supervisor: ', err);
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/apre-server/test/routes/reports/agent-performance/agent-performance-by-supervisor.spec.js
+++ b/apre-server/test/routes/reports/agent-performance/agent-performance-by-supervisor.spec.js
@@ -1,0 +1,83 @@
+/**
+ * Author: Diana ruiz Garcia
+ * Date: 9 November 2024
+ * File: agent-performance-by-supervisor.spec.js
+ * Description: Test the agent performance API for agent performance report by supervisor.
+ */
+
+// Require the modules
+const request = require('supertest');
+const app = require('../../../../src/app');
+const { mongo } = require('../../../../src/utils/mongo');
+
+
+jest.mock('../../../../src/utils/mongo');
+
+// Test the agent performance API for agent performance report by supervisor.
+describe('Apre Agent Performance API - Performance By Supervisor', () => {
+  beforeEach(() => {
+    mongo.mockClear();
+  });
+
+  // Test the agent-performance-by-supervisor endpoint
+  it('should fetch performance data for agents with a specified supervisor', async () => {
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        aggregate: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            {
+              agents: ['Mia Rodriguez', 'Mason Walker', 'Ava Lewis', 'Matthew Harris', 'Ethan Clark', 'Lucas Martinez'],
+              resolutionsTime: [150, 120, 100, 120, 130, 100]
+            }
+          ])
+        })
+      };
+      await callback(db);
+    });
+
+    const response = await request(app).get('/api/reports/agent-performance/agent-performance-by-supervisor/650c1f1e1c9d440000a1b1c4'); // Send a GET request to the agent-performance-by-supervisor endpoint
+
+    expect(response.status).toBe(200); // Expect a 200 status code
+
+    // Expect the response body to match the expected data
+    expect(response.body).toEqual([
+      {
+        agents: ['Mia Rodriguez', 'Mason Walker', 'Ava Lewis', 'Matthew Harris', 'Ethan Clark', 'Lucas Martinez'],
+        resolutionsTime: [150, 120, 100, 120, 130, 100]
+      }
+    ]);
+  });
+
+  // Test the agent-performance-by-supervisor endpoint if no supervisor is found
+  it('should return 200 with an empty array if no supervisor is found', async () => {
+    // Create a mock of the request and return data
+    mongo.mockImplementation(async (callback) => {
+      const db = {
+        collection: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockResolvedValue([])
+      };
+      await callback(db);
+    });
+
+    // Send a GET request to the agent-performance-by-supervisor endpoint
+    const response = await request(app).get('/api/reports/agent-performance/agent-performance-by-supervisor/');
+
+    // Expect the status code to be 200
+    expect(response.status).toBe(200);
+    // Expect the response to be an empty array
+    expect(response.body).toEqual([]);
+  });
+
+  // Test the agent-performance-by-supervisor endpoint with an invalid supervisor
+  it('should return 400 for an invalid endpoint', async () => {
+    const response = await request(app).get('/api/reports/agent-performance/agent-performance-by-supervisor/invalid-supervisor'); // Send a GET request to an invalid endpoint
+    expect(response.status).toBe(400); // Expect a 500 status code
+    // Expect the response body to match the expected data
+    expect(response.body).toEqual({
+      message: 'Supervisor ID is required',
+      status: 400,
+      type: 'error'
+    });
+  });
+});


### PR DESCRIPTION
I created an API to fetch agent performance data by supervisor and built an Angular component to display agent performance by supervisor using ChartComponent with 3 unit tests each.

The following folder was added to apre-client:
- agent-performance-by-supervisor (aper-client/src/app/reports/agent-performance)

Inside the above folder, I added the following files:
- agent-performance-by-supervisor.component.spec.ts
- agent-performance-by-supervisor.component.ts

Since I added a new report, update the following files:
- main-layout.component.ts (apre-client/src/app/layouts)
- app.routes.ts (apre-client/src/app)

The following files were added to apre-server: 
- agent-performance-by-supervisor.js (apre-server/src/routes/reports/agent-performance)
- agent-performance-by-supervisor.spec.js (apre-server/test/routes/reports/agent-performance)

I updated the following file to be able to use my API globally:
- app.js (apre-server/src)